### PR TITLE
Changes dynamics holder from Array to Object

### DIFF
--- a/src/interface/dss.setProperty.js
+++ b/src/interface/dss.setProperty.js
@@ -5,7 +5,7 @@
 
 	dss.core.defineMethod('setProperty',function(property,value){
 		if (!dss.core.dynamics)
-			dss.core.dynamics = [];
+			dss.core.dynamics = {};
 		dss.core.dynamics[property] = value;
 		if (dss.core.IS_INITIALIZED){
 			dss.core.refreshDss(dss.core.refreshValues);


### PR DESCRIPTION
Since properties are pure strings, dynamics holder should be an Object instead of an Array, then it will properly act like a HashMap.
